### PR TITLE
Update functions to middlewares and final format is also http handler

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -191,7 +191,7 @@ Example:
 
 ### microtik
 
-If you your microtik router does not support ipv6, then you can use the global query parameters to only return ipv4 addresses.
+If your microtik router does not support ipv6, then you can use the global query parameters to only return ipv4 addresses.
 
 Example:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -175,9 +175,9 @@ Example usage
 ```
 http://localhost:41412/security/blocklist?ipv6only
 ```
-`?nosort` - Does not sort IP's
+`?nosort` - Do not sort IP's
 
-> Only use if you do not care about the sorting of the list, can  result in average 1ms improvement 
+> Only use if you do not care about the sorting of the list, can result in average 1ms improvement 
 
 Example usage
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -204,7 +204,7 @@ Example:
 
 #### microtik query parameters
 
-`?listname=foo` - Set the list name to `foo`
+`?listname=foo` - Set the list name to `foo`, by default `listname` is set to `CrowdSec`
 
 example output:
 ```text

--- a/docker/README.md
+++ b/docker/README.md
@@ -175,6 +175,14 @@ Example usage
 ```
 http://localhost:41412/security/blocklist?ipv6only
 ```
+`?nosort` - Does not sort IP's
+
+> Only use if you do not care about the sorting of the list, can  result in average 1ms improvement 
+
+Example usage
+```
+http://localhost:41412/security/blocklist?nosort
+```
 
 ## Formats
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -160,6 +160,22 @@ Password for the provided user and using `basic` authentication.
 
 List of valid IPv4 and IPv6 IPs and ranges which have access to blocklist. It's only applicable when authentication `type` is `ip_based`.
 
+## Global RunTime Query Parameters
+
+`?ipv4only` - Only return IPv4 addresses
+
+Example usage
+```
+http://localhost:41412/security/blocklist?ipv4only
+```
+
+`?ipv6only` - Only return IPv6 addresses
+
+Example usage
+```
+http://localhost:41412/security/blocklist?ipv6only
+```
+
 ## Formats
 
 The bouncer can expose the blocklist in the following formats. You can configure the format of the blocklist by setting it's `format` parameter to any of the supported formats described below.
@@ -175,7 +191,7 @@ Example:
 
 ### microtik
 
-You must have ipv6 enabled.
+If you your microtik router does not support ipv6, then you can use the global query parameters to only return ipv4 addresses.
 
 Example:
 
@@ -184,4 +200,16 @@ Example:
 /ipv6 firewall address-list remove [find list=CrowdSec]
 /ip firewall address-list add list=CrowdSec address=1.2.3.4 comment="crowdsecurity/ssh-bf for 152h40m24.308868973s"
 /ip firewall address-list add list=CrowdSec address=4.3.2.1 comment="crowdsecurity/postfix-spam for 166h40m25.280338424s"/ipv6 firewall address-list add list=CrowdSec address=2001:470:1:c84::17 comment="crowdsecurity/ssh-bf for 165h13m42.405449876s"
+```
+
+#### microtik query parameters
+
+`?listname=foo` - Set the list name to `foo`
+
+example output:
+```text
+/ip firewall address-list remove [find list=foo]
+/ipv6 firewall address-list remove [find list=foo]
+/ip firewall address-list add list=foo address=1.2.3.4 comment="crowdsecurity/ssh-bf for 152h40m24.308868973s"
+/ip firewall address-list add list=foo address=4.3.2.1 comment="crowdsecurity/postfix-spam for 166h40m25.280338424s"/ipv6 firewall address-list add list=foo address=2001:470:1:c84::17 comment="crowdsecurity/ssh-bf for 165h13m42.405449876s"
 ```

--- a/formatters.go
+++ b/formatters.go
@@ -15,7 +15,7 @@ var FormattersByName map[string]func(w http.ResponseWriter, r *http.Request) = m
 }
 
 func PlainTextFormatter(w http.ResponseWriter, r *http.Request) {
-	decisions := r.Context().Value("decisions").([]*models.Decision)
+	decisions := r.Context().Value(globalDecisionRegistry.Key).([]*models.Decision)
 	ips := make([]string, len(decisions))
 	for i, decision := range decisions {
 		ips[i] = *decision.Value
@@ -25,7 +25,7 @@ func PlainTextFormatter(w http.ResponseWriter, r *http.Request) {
 }
 
 func MicroTikFormatter(w http.ResponseWriter, r *http.Request) {
-	decisions := r.Context().Value("decisions").([]*models.Decision)
+	decisions := r.Context().Value(globalDecisionRegistry.Key).([]*models.Decision)
 	ips := make([]string, len(decisions))
 	listName := r.URL.Query().Get("listname")
 	if listName == "" {

--- a/formatters.go
+++ b/formatters.go
@@ -37,8 +37,9 @@ func MicroTikFormatter(w http.ResponseWriter, r *http.Request) {
 			ipType = "/ipv6"
 		}
 		ips[i] = fmt.Sprintf(
-			"%s firewall address-list add list=CrowdSec address=%s comment=\"%s for %s\"",
+			"%s firewall address-list add list=%s address=%s comment=\"%s for %s\"",
 			ipType,
+			listName,
 			*decision.Value,
 			*decision.Scenario,
 			*decision.Duration,

--- a/formatters.go
+++ b/formatters.go
@@ -46,7 +46,11 @@ func MicroTikFormatter(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 	sort.Strings(ips)
-	w.Write([]byte(fmt.Sprintf("/ip firewall address-list remove [find list=%s]\n", listName) +
-		fmt.Sprintf("/ipv6 firewall address-list remove [find list=%s]\n", listName) +
-		strings.Join(ips, "\n")))
+	if !r.URL.Query().Has("ipv6only") {
+		w.Write([]byte(fmt.Sprintf("/ip firewall address-list remove [find list=%s]\n", listName)))
+	}
+	if !r.URL.Query().Has("ipv4only") {
+		w.Write([]byte(fmt.Sprintf("/ipv6 firewall address-list remove [find list=%s]\n", listName)))
+	}
+	w.Write([]byte(strings.Join(ips, "\n")))
 }

--- a/formatters.go
+++ b/formatters.go
@@ -2,28 +2,35 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 )
 
-var FormattersByName map[string]func([]*models.Decision) string = map[string]func([]*models.Decision) string{
+var FormattersByName map[string]func(w http.ResponseWriter, r *http.Request) = map[string]func(w http.ResponseWriter, r *http.Request){
 	"plain_text": PlainTextFormatter,
 	"microtik":   MicroTikFormatter,
 }
 
-func PlainTextFormatter(decisions []*models.Decision) string {
+func PlainTextFormatter(w http.ResponseWriter, r *http.Request) {
+	decisions := r.Context().Value("decisions").([]*models.Decision)
 	ips := make([]string, len(decisions))
 	for i, decision := range decisions {
 		ips[i] = *decision.Value
 	}
 	sort.Strings(ips)
-	return strings.Join(ips, "\n")
+	w.Write([]byte(strings.Join(ips, "\n")))
 }
 
-func MicroTikFormatter(decisions []*models.Decision) string {
+func MicroTikFormatter(w http.ResponseWriter, r *http.Request) {
+	decisions := r.Context().Value("decisions").([]*models.Decision)
 	ips := make([]string, len(decisions))
+	listName := r.URL.Query().Get("listname")
+	if listName == "" {
+		listName = "CrowdSec"
+	}
 	for i, decision := range decisions {
 		var ipType = "/ip"
 		if strings.Contains(*decision.Value, ":") {
@@ -38,7 +45,7 @@ func MicroTikFormatter(decisions []*models.Decision) string {
 		)
 	}
 	sort.Strings(ips)
-	return "/ip firewall address-list remove [find list=CrowdSec]\n" +
-		"/ipv6 firewall address-list remove [find list=CrowdSec]\n" +
-		strings.Join(ips, "\n")
+	w.Write([]byte(fmt.Sprintf("/ip firewall address-list remove [find list=%s]\n", listName) +
+		fmt.Sprintf("/ipv6 firewall address-list remove [find list=%s]\n", listName) +
+		strings.Join(ips, "\n")))
 }

--- a/server.go
+++ b/server.go
@@ -51,9 +51,9 @@ func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
 
 func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Decision {
 	ret := make([]*models.Decision, 0)
-	if filter.Has("ipv4only") && filter.Get("ipv4only") == "true" {
+	if filter.Has("ipv4only") {
 		dr.GetActiveIPV4Decisions(&ret)
-	} else if filter.Has("ipv6only") && filter.Get("ipv6only") == "true" {
+	} else if filter.Has("ipv6only") {
 		dr.GetActiveIPV6Decisions(&ret)
 	} else {
 		ret = make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))

--- a/server.go
+++ b/server.go
@@ -51,16 +51,12 @@ func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
 }
 
 func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Decision {
-	ret := make([]*models.Decision, 0)
-	if filter.Has("ipv4only") {
-		dr.GetActiveIPV4Decisions(&ret)
-	} else if filter.Has("ipv6only") {
+	ret := make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
+	if !filter.Has("ipv4only") {
 		dr.GetActiveIPV6Decisions(&ret)
-	} else {
-		ret = make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
-		for _, v := range dr.ActiveDecisionsByValue {
-			ret = append(ret, v)
-		}
+	}
+	if !filter.Has("ipv6only") {
+		dr.GetActiveIPV4Decisions(&ret)
 	}
 	sort.SliceStable(ret, func(i, j int) bool {
 		return *ret[i].Value < *ret[j].Value

--- a/server.go
+++ b/server.go
@@ -1,17 +1,19 @@
 package main
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
-	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 var RouteHits = prometheus.NewCounterVec(
@@ -46,14 +48,37 @@ func (dr *DecisionRegistry) AddDecisions(decisions []*models.Decision) {
 	}
 }
 
-func (dr *DecisionRegistry) GetActiveDecisions() []*models.Decision {
-	ret := make([]*models.Decision, len(dr.ActiveDecisionsByValue))
-	i := 0
-	for _, v := range dr.ActiveDecisionsByValue {
-		ret[i] = v
-		i++
+func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Decision {
+	ret := make([]*models.Decision, 0)
+	if filter.Has("ipv4only") && filter.Get("ipv4only") == "true" {
+		dr.GetActiveIPV4Decisions(&ret)
+	} else if filter.Has("ipv6only") && filter.Get("ipv6only") == "true" {
+		dr.GetActiveIPV6Decisions(&ret)
+	} else {
+		ret = make([]*models.Decision, 0, len(dr.ActiveDecisionsByValue))
+		for _, v := range dr.ActiveDecisionsByValue {
+			ret = append(ret, v)
+		}
 	}
 	return ret
+}
+
+func (dr *DecisionRegistry) GetActiveIPV4Decisions(ret *[]*models.Decision) {
+	for _, v := range dr.ActiveDecisionsByValue {
+		if strings.Contains(*v.Value, ":") {
+			continue
+		}
+		*ret = append(*ret, v)
+	}
+}
+
+func (dr *DecisionRegistry) GetActiveIPV6Decisions(ret *[]*models.Decision) {
+	for _, v := range dr.ActiveDecisionsByValue {
+		if strings.Contains(*v.Value, ".") {
+			continue
+		}
+		*ret = append(*ret, v)
+	}
 }
 
 func (dr *DecisionRegistry) DeleteDecisions(decisions []*models.Decision) {
@@ -76,6 +101,10 @@ func satisfiesBasicAuth(r *http.Request, user, password string) bool {
 	}
 	expectedVal := fmt.Sprintf("Basic %s", basicAuth(user, password))
 	foundVal := r.Header[http.CanonicalHeaderKey("Authorization")][0]
+	log.WithFields(logrus.Fields{
+		"expected": expectedVal,
+		"found":    foundVal,
+	}).Debug("checking basic auth")
 	return expectedVal == foundVal
 }
 
@@ -113,23 +142,41 @@ func networksContainIP(networks []net.IPNet, ip string) bool {
 	return false
 }
 
-func getHandlerForBlockList(blockListCfg *BlockListConfig) (func(w http.ResponseWriter, r *http.Request), error) {
-	trustedIPs, err := getTrustedIPs(blockListCfg.Authentication.TrustedIPs)
-	if err != nil {
-		return nil, err
-	}
-	f := func(w http.ResponseWriter, r *http.Request) {
+func metricsMiddleware(blockListCfg *BlockListConfig, next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		RouteHits.WithLabelValues(
 			blockListCfg.Endpoint,
 		).Inc()
+		next.ServeHTTP(w, r)
+	}
+}
 
+func decisionMiddleware(next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		decisions := globalDecisionRegistry.GetActiveDecisions(r.URL.Query())
+		if len(decisions) == 0 {
+			http.Error(w, "no decisions available", http.StatusNotFound)
+			return
+		}
+		ctx := context.WithValue(r.Context(), "decisions", decisions)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+}
+
+func authMiddleware(blockListCfg *BlockListConfig, next http.HandlerFunc) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
 		ip, _, err := net.SplitHostPort(r.RemoteAddr)
 		if err != nil {
 			logrus.Errorf("error while spliting hostport for %s: %v", r.RemoteAddr, err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
-
+		trustedIPs, err := getTrustedIPs(blockListCfg.Authentication.TrustedIPs)
+		if err != nil {
+			logrus.Errorf("error while parsing trusted IPs: %v", err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
+			return
+		}
 		switch strings.ToLower(blockListCfg.Authentication.Type) {
 		case "ip_based":
 			if !networksContainIP(trustedIPs, ip) {
@@ -143,13 +190,13 @@ func getHandlerForBlockList(blockListCfg *BlockListConfig) (func(w http.Response
 			}
 		case "", "none":
 		}
-
-		if _, ok := FormattersByName[blockListCfg.Format]; !ok {
-			log.Fatal("unsupported format")
-		}
-		w.Write(
-			[]byte(FormattersByName[blockListCfg.Format](globalDecisionRegistry.GetActiveDecisions())),
-		)
+		next.ServeHTTP(w, r)
 	}
-	return f, nil
+}
+
+func getHandlerForBlockList(blockListCfg *BlockListConfig) (func(w http.ResponseWriter, r *http.Request), error) {
+	if _, ok := FormattersByName[blockListCfg.Format]; !ok {
+		log.Fatal("unsupported format")
+	}
+	return authMiddleware(blockListCfg, metricsMiddleware(blockListCfg, decisionMiddleware(FormattersByName[blockListCfg.Format]))), nil
 }

--- a/server.go
+++ b/server.go
@@ -58,9 +58,11 @@ func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Deci
 	if !filter.Has("ipv6only") {
 		dr.GetActiveIPV4Decisions(&ret)
 	}
-	sort.SliceStable(ret, func(i, j int) bool {
-		return *ret[i].Value < *ret[j].Value
-	})
+	if !filter.Has("nosort") {
+		sort.SliceStable(ret, func(i, j int) bool {
+			return *ret[i].Value < *ret[j].Value
+		})
+	}
 	return ret
 }
 

--- a/server.go
+++ b/server.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/crowdsecurity/crowdsec/pkg/models"
@@ -61,6 +62,9 @@ func (dr *DecisionRegistry) GetActiveDecisions(filter url.Values) []*models.Deci
 			ret = append(ret, v)
 		}
 	}
+	sort.SliceStable(ret, func(i, j int) bool {
+		return *ret[i].Value < *ret[j].Value
+	})
 	return ret
 }
 

--- a/server.go
+++ b/server.go
@@ -197,7 +197,7 @@ func authMiddleware(blockListCfg *BlockListConfig, next http.HandlerFunc) func(w
 
 func getHandlerForBlockList(blockListCfg *BlockListConfig) (func(w http.ResponseWriter, r *http.Request), error) {
 	if _, ok := FormattersByName[blockListCfg.Format]; !ok {
-		log.Fatal("unsupported format")
+		return nil, fmt.Errorf("unknown format %s", blockListCfg.Format)
 	}
 	return authMiddleware(blockListCfg, metricsMiddleware(blockListCfg, decisionMiddleware(FormattersByName[blockListCfg.Format]))), nil
 }


### PR DESCRIPTION
Allow option for #12 
Allow customisation of microtik listname @williamdes

Convert other functions into middlewares so early return is simpler

Memory consumption is a little concern due to filters, however, stress testing only shown a 6mb increase. 

When I mean stress test that was 1k request per second over 10 minutes.