### PR TITLE
allow to specify 'scopes' in the configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,6 +101,7 @@ func Execute() error {
 			ScenariosContaining:    strings.Join(config.CrowdsecConfig.IncludeScenariosContaining, ","),
 			ScenariosNotContaining: strings.Join(config.CrowdsecConfig.ExcludeScenariosContaining, ","),
 			Origins:                strings.Join(config.CrowdsecConfig.OnlyIncludeDecisionsFrom, ","),
+			Scopes:                 strings.Join(config.CrowdsecConfig.Scopes, ","),
 		},
 		UserAgent:          "crowdsec-blocklist-mirror/" + version.String(),
 		CertPath:           config.CrowdsecConfig.CertPath,

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -30,6 +30,7 @@ type CrowdsecConfig struct {
 	IncludeScenariosContaining []string `yaml:"include_scenarios_containing"`
 	ExcludeScenariosContaining []string `yaml:"exclude_scenarios_containing"`
 	OnlyIncludeDecisionsFrom   []string `yaml:"only_include_decisions_from"`
+	Scopes                     []string `yaml:"scopes,omitempty"`
 }
 
 type BlockListConfig struct {


### PR DESCRIPTION
By default, the bouncer was limited to making IP-based decisions.

This pull request now allows the bouncer to make non-IP based decisions using the `Scopes` parameter.

