### PR TITLE
enhance: Add proper headers to prompt for basic auth

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -108,11 +108,6 @@ func basicAuth(username, password string) string {
 func satisfiesBasicAuth(r *http.Request, user, password string) bool {
 	expectedVal := "Basic " + basicAuth(user, password)
 	foundVal := r.Header.Get("Authorization")
-	log.WithFields(log.Fields{
-		"expected": expectedVal,
-		"found":    foundVal,
-	}).Debug("checking basic auth")
-
 	return expectedVal == foundVal
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -106,12 +106,8 @@ func basicAuth(username, password string) string {
 }
 
 func satisfiesBasicAuth(r *http.Request, user, password string) bool {
-	if _, ok := r.Header[http.CanonicalHeaderKey("Authorization")]; !ok {
-		return false
-	}
-
 	expectedVal := "Basic " + basicAuth(user, password)
-	foundVal := r.Header[http.CanonicalHeaderKey("Authorization")][0]
+	foundVal := r.Header.Get("Authorization")
 	log.WithFields(log.Fields{
 		"expected": expectedVal,
 		"found":    foundVal,
@@ -207,6 +203,11 @@ func authMiddleware(blockListCfg *cfg.BlockListConfig, next http.HandlerFunc) fu
 				return
 			}
 		case "basic":
+			if r.Header.Get("Authorization") == "" {
+				w.Header().Set("WWW-Authenticate", "Basic realm=\"crowdsec-blocklist-mirror\"")
+				http.Error(w, "access denied", http.StatusUnauthorized)
+				return
+			}
 			if !satisfiesBasicAuth(r, blockListCfg.Authentication.User, blockListCfg.Authentication.Password) {
 				http.Error(w, "access denied", http.StatusForbidden)
 				return


### PR DESCRIPTION
We do not set the proper return status or headers by RFC for basic authentication this PR changes it.